### PR TITLE
add Visual Studio Code plugin details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ according to **rufo**, and will exit with exit code 1.
 ## Editor support
 
 - Sublime Text: [sublime-rufo](https://github.com/asterite/sublime-rufo)
+- Visual Studio Code: [rufo-vscode](https://marketplace.visualstudio.com/items?itemName=siliconsenthil.rufo-vscode)
 - Vim: [rufo-vim](https://github.com/splattael/rufo-vim) :construction:
 - Atom: [rufo-atom](https://github.com/bmulvihill/rufo-atom) :construction:
 - Emacs [emacs-rufo](https://github.com/aleandros/emacs-rufo) :construction:


### PR DESCRIPTION
I use Visual Studio Code for `ruby` development. I could not find a good ruby formatter there.

Thanks to `rufo`, I have found a way and added an extension. This PR adds the detail of the extension to README. 

Please merge. Thanks

