### PR TITLE
Breaks on newline before argument declaration in block

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1492,7 +1492,7 @@ class Rufo::Formatter
 
   def consume_block_args(args)
     if args
-      consume_one_dynamic_space_no_more_than_one @spaces_around_block_brace
+      consume_one_dynamic_space_or_newline @spaces_around_block_brace
       # + 1 because of |...|
       #                ^
       indent(@column + 1) do

--- a/spec/rufo_spec.rb
+++ b/spec/rufo_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Rufo do
   assert_format "proc { |(w, *x, y), z| }"
   assert_format "foo { |(*x , y), z| }"
   assert_format "foo { begin; end; }", "foo { begin; end }"
-  assert_format "foo {\n |i| }"
+  assert_format "foo {\n |i| }", "foo {\n  |i| }\n"
 
   # Calls with receiver and block
   assert_format "foo.bar 1 do \n end", "foo.bar 1 do\nend"

--- a/spec/rufo_spec.rb
+++ b/spec/rufo_spec.rb
@@ -412,6 +412,7 @@ RSpec.describe Rufo do
   assert_format "proc { |(w, *x, y), z| }"
   assert_format "foo { |(*x , y), z| }"
   assert_format "foo { begin; end; }", "foo { begin; end }"
+  assert_format "foo {\n |i| }"
 
   # Calls with receiver and block
   assert_format "foo.bar 1 do \n end", "foo.bar 1 do\nend"


### PR DESCRIPTION
Code like this breaks rufo:

```ruby
  [1,2,3].select {
     |i| puts 'rufo bug here!'
  }
```

Hopefully this patch fixes it.