### PR TITLE
Support for `bodystmt` in `do_block`

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1512,10 +1512,14 @@ class Rufo::Formatter
 
     consume_block_args args
 
-    indent_body body
-
-    write_indent if @line != line
-    consume_keyword "end"
+    if body.first == :bodystmt
+      visit_bodystmt body
+      write_indent unless @line == line
+    else
+      indent_body body
+      write_indent unless @line == line
+      consume_keyword "end"
+    end
   end
 
   def consume_block_args(args)


### PR DESCRIPTION
Since 2.5, `rescue` can be placed in `do` block without
surrounding `begin`/`end`.
c.f. https://bugs.ruby-lang.org/issues/12906
ruby/ruby@0ec889d7ed34f80b534dfc7a93bdd3175aba9ff9

Fixes #97.