### PR TITLE
Add :one option to spaces_after_lambda_arrow

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2485,6 +2485,9 @@ class Rufo::Formatter
 
     if space? && @spaces_after_lambda_arrow == :dynamic
       consume_space(want_preserve_whitespace: true)
+    elsif @spaces_after_lambda_arrow == :one
+      skip_space
+      write_space
     else
       skip_space_or_newline
     end

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -77,7 +77,7 @@ class Rufo::Formatter
   end
 
   def spaces_after_lambda_arrow(value)
-    @spaces_after_lambda_arrow = no_dynamic("spaces_after_lambda_arrow", value)
+    @spaces_after_lambda_arrow = one_no_dynamic("spaces_after_lambda_arrow", value)
   end
 
   def spaces_around_unary(value)
@@ -175,6 +175,15 @@ class Rufo::Formatter
       value
     else
       raise ArgumentError.new("invalid value for #{name}: #{value}. Valid values are: :no, :dynamic")
+    end
+  end
+
+  def one_no_dynamic(name, value)
+    case value
+    when :no, :one, :dynamic
+      value
+    else
+      raise ArgumentError.new("invalid value for #{name}: #{value}. Valid values are: :no, :one, :dynamic")
     end
   end
 

--- a/spec/rufo_spec.rb
+++ b/spec/rufo_spec.rb
@@ -995,6 +995,8 @@ RSpec.describe Rufo do
   # spaces_after_lambda_arrow
   assert_format "->  { }", "->  { }", spaces_after_lambda_arrow: :dynamic
   assert_format "->  { }", "->{ }", spaces_after_lambda_arrow: :no
+  assert_format "->  { }", "-> { }", spaces_after_lambda_arrow: :one
+  assert_format "->{ }", "-> { }", spaces_after_lambda_arrow: :one
 
   # spaces_around_unary
   assert_format "- x", "- x", spaces_around_unary: :dynamic


### PR DESCRIPTION
I like [the good way style in bbatsov's ruby-style-guide](https://github.com/bbatsov/ruby-style-guide#stabby-lambda-no-args). I'd be happy to be able to format this 😃 

```
# before
->{ some_method }
->  { some_method }

# after
-> { some_method }
```